### PR TITLE
Update and add a bunch of links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,37 +3,37 @@ This is a live and open listing of known FHIR bulk data implementations per the 
 ## Known Implementations
 
 - **Google**
-    - **Google Bulk FHIR client, library, and workflow**: [https://github.com/google/bulk_fhir_tools](https://github.com/google/bulk_fhir_tools)
-    - **Google Cloud Healthcare API** [https://cloud.google.com/blog/topics/healthcare-life-sciences/getting-to-know-the-google-cloud-healthcare-api-part-1](https://cloud.google.com/blog/topics/healthcare-life-sciences/getting-to-know-the-google-cloud-healthcare-api-part-1)
-- **IBM**
-    - **Client** [https://github.com/IBM/FHIR](https://github.com/IBM/FHIR)
-    - **Server** [https://ibm.github.io/FHIR/guides/FHIRBulkOperations/](https://ibm.github.io/FHIR/guides/FHIRBulkOperations/)
-    - **IBM Watson Health** (bulk data support in development)
+    - [Google Bulk FHIR client, library, and workflow](https://github.com/google/bulk_fhir_tools)
+    - [Google Cloud Healthcare API](https://cloud.google.com/blog/topics/healthcare-life-sciences/getting-to-know-the-google-cloud-healthcare-api-part-1)
+- **Linux for Health**
+    - [Server and client](https://linuxforhealth.github.io/FHIR/)
 - **Microsoft**
-    -**Azure Api for FHIR** [https://github.com/microsoft/fhir-server-samples](https://github.com/microsoft/fhir-server-samples)
+    - [Azure Health Data Services](https://learn.microsoft.com/en-us/azure/healthcare-apis/fhir/export-data)
 - **CMS**
-    - **Data at the Point of Care** [https://dpc.cms.gov/](https://dpc.cms.gov/)
-    - **Beneficiary Claims Data API** [https://bcda.cms.gov/](https://bcda.cms.gov/)
-- **Cerner** (bulk data support in development)
-- **EPIC** (bulk data support in development)
-- **Meditech** (bulk data support in development)
-- **Humana** (bulk data support in development)
-- **Aetna** (bulk data support in development)
-- **Oracle** (bulk data support in development)
-- **Allscripts** (bulk data support in development)
-- **Fire.ly**
-    - **Vonk FHIR Server** [https://vonk.fire.ly/](https://vonk.fire.ly/)
-- **SMILE CDR**
-    - **Bulk FHIR Server** [https://smilecdr.com/docs/bulk/fhir_bulk_export.html](https://smilecdr.com/docs/bulk/fhir_bulk_export.html)
+    - [Data at the Point of Care](https://dpc.cms.gov/)
+    - [Beneficiary Claims Data API](https://bcda.cms.gov/)
+- **Oracle**
+    - [Oracle Health Millennium](https://docs.oracle.com/en/industries/health/millennium-platform-apis/mfbda/index.html) 
+- **Epic**
+    - [Epic FHIR server](https://fhir.epic.com/Documentation?docId=fhir_bulk_data)
+- **Meditech**
+    - [Meditech FHIR server](https://fhir.meditech.com/explorer/api/uscore.R4._/2)
+- **Veradigm**
+    - [Veradigm FHIR server](https://developer.veradigm.com/Fhir/BulkData)
+- **Firely**
+    - [Firely Server](https://docs.fire.ly/projects/Firely-Server/en/latest/features_and_tools/bulkdataexport.html)
+- **Smile**
+    - [Smile CDR](https://smilecdr.com/docs/bulk/fhir_bulk_export.html)
 - **MITRE**
-    - **Inferno Community** [https://inferno.healthit.gov/community and https://github.com/onc-healthit/inferno](https://inferno.healthit.gov/community and https://github.com/onc-healthit/inferno)
-    - **Inferno Program** [https://inferno.healthit.gov/inferno and https://github.com/onc-healthit/inferno-program](https://inferno.healthit.gov/inferno and https://github.com/onc-healthit/inferno-program) (tied to 170.315(g)(10) Multi-Patient Query)
-- **1up Health**
-    - **SQL Analytics API** [https://1up.health/dev/fhir-analytics](https://1up.health/dev/fhir-analytics)
+    - [Inferno Bulk Data Test Kit](https://inferno.healthit.gov/test-kits/bulk-data/)
+    - [Inferno ONC Certification (g)(10) Standardized API Test Kit](https://inferno.healthit.gov/test-kits/onc-certification-g10/) (tied to 170.315(g)(10) Multi-Patient Query)
+- **1upHealth**
+    - [1up Exchange](https://docs.1up.health/help-center/Content/en-US/exchange/exchange.html)
 - **SMART Health IT**
-    - **Client** [https://github.com/smart-on-fhir/sample-apps-stu3/tree/master/fhir-downloader](https://github.com/smart-on-fhir/sample-apps-stu3/tree/master/fhir-downloader)
-    - **Server** [https://bulk-data.smarthealthit.org/](https://bulk-data.smarthealthit.org/)
-- **Medplum** [https://www.medplum.com/docs/api/fhir/operations/bulk-fhir](https://www.medplum.com/docs/api/fhir/operations/bulk-fhir)
+    - [Bulk Data Client](https://github.com/smart-on-fhir/bulk-data-client)
+    - [Bulk Data Server](https://bulk-data.smarthealthit.org/)
+- **Medplum**
+    - [Medplum FHIR server](https://www.medplum.com/docs/api/fhir/operations/bulk-fhir)
 
 
 ### Editing this list


### PR DESCRIPTION
Style changes:
- Made the text the link, rather than showing the full URL as text

Content changes:
- IBM -> Linux for Health
- Microsoft: update link
- Cerner -> Oracle and add link to docs
- Epic: add link to docs
- Meditech: add links to docs
- Humana: drop from list for now, couldn't find docs (**Vlad, is this right?**)
- Aetna: drop from list for now, couldn't find docs (**Vlad, is this right?**)
- Allscripts -> Veradigm and add links to docs
- Firely: update link
- MITRE: update links
- 1upHealth: update link
- SMART: update link